### PR TITLE
Performance improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 
 - [ ] Plug with async/IO event libraries (such as libevent/libuv)
-- [ ] Pooling/garbage collection of structures
+- [x] Pooling/garbage collection of structures ~~(may add more later, and pool msgs structures and buffers, but that would introduce locking which may negate the benefits of the pooling)~~
 - [x] ~~Revisit connect logic to match GO Client~~ *Will actually do the opposite, that is change the GO Client connect/reconnect logic. The async reconnect logic is flawed and could cause issues when getting authentication errors during the process.*
 - [x] Revisit FlushTimeout to match GO Client
 - [ ] Revisit Flusher for the aggregation of more data before socket write

--- a/src/gc.h
+++ b/src/gc.h
@@ -1,0 +1,27 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+
+#ifndef GC_H_
+#define GC_H_
+
+// This callback implements the specific code to free the given object.
+// This is invoked by the garbage collector.
+typedef void (*nats_FreeObjectCb)(void *object);
+
+// This structure should be included as the first field of any object
+// that needs to be garbage collected.
+typedef struct __natsGCItem
+{
+    struct __natsGCItem     *next;
+    nats_FreeObjectCb       freeCb;
+
+} natsGCItem;
+
+// Gives the object to the garbage collector.
+// Returns 'true' if the GC takes ownership, 'false' otherwise (in this case,
+// the caller is responsible for freeing the object).
+bool
+natsGC_collect(natsGCItem *item);
+
+
+#endif /* GC_H_ */

--- a/src/msg.h
+++ b/src/msg.h
@@ -4,14 +4,23 @@
 #define MSG_H_
 
 #include "status.h"
+#include "gc.h"
 
 struct __natsMsg;
 
 typedef struct __natsMsg
 {
-    char                *subject;
-    char                *reply;
-    char                *data;
+    natsGCItem          gc;
+
+    // This holds subject, reply and payload.
+    char                *buffer;
+
+    // These points to specific locations in 'buffer'. They must not be freed.
+    // (note that we could do without 'subject' since as of now, it is
+    // equivalent to 'buffer').
+    const char          *subject;
+    const char          *reply;
+    const char          *data;
     int                 dataLen;
 
     struct __natsMsg    *next;
@@ -21,7 +30,14 @@ typedef struct __natsMsg
 // PRIVATE
 
 natsStatus
-natsMsg_create(natsMsg **newMsg, char *buf, int bufLen);
+natsMsg_create(natsMsg **newMsg,
+               const char *subject, int subjLen,
+               const char *reply, int replyLen,
+               const char *buf, int bufLen);
+
+// This needs to follow the nats_FreeObjectCb prototype (see gc.h)
+void
+natsMsg_free(void *object);
 
 
 // PUBLIC

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -177,6 +177,9 @@ typedef struct __natsSubscription
 
     natsThread                  *deliverMsgsThread;
     natsCondition               *cond;
+    natsTimer                   *signalTimer;
+    int64_t                     signalTimerInterval;
+    int                         signalFailCount;
     bool                        signaled;
     bool                        closed;
 

--- a/src/sub.h
+++ b/src/sub.h
@@ -30,6 +30,9 @@ natsStatus
 natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
                const char *queueGroup, natsMsgHandler cb, void *cbClosure);
 
+void
+natsSub_close(natsSubscription *sub);
+
 // PUBLIC
 
 natsStatus


### PR DESCRIPTION
* Add a "garbage collector" that is responsible for invoking an object's "free" callback. The advantage is to move the cost of freeing objects outside of the fast path.
* Subject, Reply and Payload are now allocated as a single memory block. This reduces the number of malloc/free calls.
* Introduced a "signal" timer in each subscription to reduce number of signals and contention. This may increase the risk of reaching the number of max pending messages,
though, so may need some teaking or make it an option.