### PR TITLE
Fix `undefined reference to 'clock_gettime'` issue on some Linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ include(CTest)
 set(NATS_INSTALL_PREFIX ../install CACHE PATH "Install prefix")
 set(CMAKE_INSTALL_PREFIX ${NATS_INSTALL_PREFIX} CACHE INTERNAL "")
 
+option(NATS_UPDATE_VERSION "Update the version file" OFF)
+
 # Platform specific settings
 if(UNIX)
   #---------------------------------------------------------------------------
@@ -46,6 +48,7 @@ if(UNIX)
   else(APPLE)
     set(NATS_OS "LINUX")
     set(NATS_USE_PTHREAD "-pthread")
+    set(NATS_EXTRA_LIB "rt")
   endif(APPLE)
   
   if (${NATS_BUILD_ARCH} MATCHES "32")
@@ -70,10 +73,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NATS_COMMON_C_FLAGS} ${NATS_USE_PTHREAD} $
 add_definitions(-D${NATS_OS})
 add_definitions(-D_REENTRANT)
 
-if (DEFINED ENV{TRAVIS})
-add_definitions(-DTRAVIS)
-endif()
-
 #---------------------------------------------------------------------
 # Add to the 'clean' target the list (and location) of files to remove
 
@@ -86,12 +85,13 @@ list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/lib/${nats_static}")
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${NATS_INSTALLED_FILES}")
 #---------------------------------------------------------------------
 
+if(NATS_UPDATE_VERSION)
 #------------
 # Versionning
 
 set(NATS_VERSION_MAJOR  1)
 set(NATS_VERSION_MINOR  1)
-set(NATS_VERSION_PATCH  0)
+set(NATS_VERSION_PATCH  1)
 set(NATS_VERSION_SUFFIX "")
 
 set(NATS_VERSION_REQUIRED_NUMBER 0x010100)
@@ -106,6 +106,7 @@ configure_file(
 	${CMAKE_SOURCE_DIR}/doc/DoxyFile.NATS.Client
 	@ONLY)
 #------------
+endif()
 
 #----------------------------
 # Add the project directories

--- a/doc/DoxyFile.NATS.Client
+++ b/doc/DoxyFile.NATS.Client
@@ -38,7 +38,7 @@ PROJECT_NAME           = "NATS C Client"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1.0
+PROJECT_NUMBER         = 1.1.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
+++ b/doc/html/dir_68267d1309a1af8e8297ef4c3efbcdba.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/files.html
+++ b/doc/html/files.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals.html
+++ b/doc/html/globals.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals_defs.html
+++ b/doc/html/globals_defs.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals_enum.html
+++ b/doc/html/globals_enum.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals_eval.html
+++ b/doc/html/globals_eval.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals_func.html
+++ b/doc/html/globals_func.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/globals_type.html
+++ b/doc/html/globals_type.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__callbacks_group.html
+++ b/doc/html/group__callbacks_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__conn_group.html
+++ b/doc/html/group__conn_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__conn_mgt_group.html
+++ b/doc/html/group__conn_mgt_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__conn_pub_group.html
+++ b/doc/html/group__conn_pub_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__conn_sub_group.html
+++ b/doc/html/group__conn_sub_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__func_group.html
+++ b/doc/html/group__func_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__inbox_group.html
+++ b/doc/html/group__inbox_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__library_group.html
+++ b/doc/html/group__library_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__msg_group.html
+++ b/doc/html/group__msg_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__opts_group.html
+++ b/doc/html/group__opts_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__stats_group.html
+++ b/doc/html/group__stats_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__status_group.html
+++ b/doc/html/group__status_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__sub_group.html
+++ b/doc/html/group__sub_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__types_group.html
+++ b/doc/html/group__types_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/group__wildcards_group.html
+++ b/doc/html/group__wildcards_group.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/modules.html
+++ b/doc/html/modules.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/nats_8h.html
+++ b/doc/html/nats_8h.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/nats_8h_source.html
+++ b/doc/html/nats_8h_source.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/status_8h.html
+++ b/doc/html/status_8h.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/doc/html/status_8h_source.html
+++ b/doc/html/status_8h_source.html
@@ -33,7 +33,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;" >
    <div id="projectname">NATS C Client
-   &#160;<span id="projectnumber">1.1.0</span>
+   &#160;<span id="projectnumber">1.1.1</span>
    </div>
    <div id="projectbrief">The nats.io C Client, Supported by Apcera</div>
   </td>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(examples_src ${EXAMPLES_SOURCES})
     add_executable(${exampleexe} ${PROJECT_SOURCE_DIR}/examples/${examples_src} )
 
     # Link dynamically
-    target_link_libraries(${exampleexe} nats)
+    target_link_libraries(${exampleexe} nats ${NATS_EXTRA_LIB})
 
 endforeach()
 

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -14,7 +14,7 @@ nats_Now(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm);
-#elif defined (CLOCK_MONOTONIC) && !defined (TRAVIS)
+#elif defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();
@@ -34,7 +34,7 @@ nats_NowInNanoSeconds(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm) * 1000000L;
-#elif defined (CLOCK_MONOTONIC) && !defined (TRAVIS)
+#elif defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();

--- a/src/version.h
+++ b/src/version.h
@@ -12,9 +12,9 @@ extern "C" {
 
 #define NATS_VERSION_MAJOR  1
 #define NATS_VERSION_MINOR  1
-#define NATS_VERSION_PATCH  0 
+#define NATS_VERSION_PATCH  1 
 
-#define NATS_VERSION_STRING "1.1.0"
+#define NATS_VERSION_STRING "1.1.1"
 			 				  
 #define NATS_VERSION_NUMBER ((NATS_VERSION_MAJOR << 16) | \
                              (NATS_VERSION_MINOR <<  8) | \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 add_executable(testsuite test.c)
 
 # Link statically with the library
-target_link_libraries(testsuite nats_static)
+target_link_libraries(testsuite nats_static ${NATS_EXTRA_LIB})
 
 # Set the test index to 0
 set(testIndex 0)


### PR DESCRIPTION
* Issue with with hosts running older glibc versions. Adding "-lrt" to the end of the link command line
* Make the generation of the version header file optional to reduce unecessary rebuilds.