### PR TITLE
Fix sendConnect() call when Verbose is set

### DIFF
--- a/src/comsock.h
+++ b/src/comsock.h
@@ -25,8 +25,13 @@ natsSock_IsConnected(natsSock fd);
 // error occurs.
 // Handles blocking and non-blocking sockets. For the later, an optional 'deadline'
 // indicates how long it can wait for the full read to complete.
+//
+// NOTE: 'buffer[0]' must be set to '\0' prior to the very first call. If the
+// peer is sending multiple lines, it is possible that this function reads the
+// next line(s) (or partials) in a single call. In this case, the caller needs
+// to repeat the call with the same buffer to "read" the next line.
 natsStatus
-natsSock_ReadLine(natsSockCtx *ctx, char *buffer, size_t maxBufferSize, int *n);
+natsSock_ReadLine(natsSockCtx *ctx, char *buffer, size_t maxBufferSize);
 
 // Reads up to 'maxBufferSize' bytes from the socket and put them in 'buffer'.
 // If the socket is blocking, wait until some data is available or the socket

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -64,6 +64,7 @@
 #define _PONG_OP_LEN_       (4)
 #define _PING_PROTO_LEN_    (6)
 #define _PONG_PROTO_LEN_    (6)
+#define _OK_OP_LEN_         (3)
 
 extern int64_t gLockSpinCount;
 

--- a/src/util.c
+++ b/src/util.c
@@ -42,7 +42,7 @@ nats_ParseControl(natsControl *control, const char *line)
     char        *tok        = NULL;
     int         len         = 0;
 
-    if (line == NULL)
+    if ((line == NULL) || (line[0] == '\0'))
         return nats_setDefaultError(NATS_PROTOCOL_ERROR);
 
     tok = strchr(line, (int) ' ');

--- a/test/list.txt
+++ b/test/list.txt
@@ -17,6 +17,7 @@ natsHashing
 natsStrHash
 natsInbox
 natsOptions
+natsSock_ReadLine
 ReconnectServerStats
 ParseStateReconnectFunctionality
 ServersRandomize
@@ -29,6 +30,7 @@ ConnClosedCB
 CloseDisconnectedCB
 ServerStopDisconnectedCB
 ClosedConnections
+ConnectVerboseOption
 ReconnectTotalTime
 ReconnectDisallowedFlags
 ReconnectAllowedFlags
@@ -80,6 +82,7 @@ SSLVerify
 SSLVerifyHostname
 SSLCiphers
 SSLMultithreads
+SSLConnectVerboseOption
 ServersOption
 AuthServers
 AuthFailToReconnect


### PR DESCRIPTION
During a (re)connect, the client is sending the CONNECT and PING protocol and expect a PONG. However, when Verbose option is set, the server will send "+OK" after receiving the CONNECT protocol. The client now dequeues the two protocols in that scenario.

* In sendConnect(), expect "+OK" when Verbose is set
* Change natsSock_ReadLine() to handle possible multiple line in single call.
* Add tests

Fixes #13