### PR TITLE
Fix Publish and Flush calls to not fail on async error (slow consumer)

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -153,11 +153,6 @@ struct __natsSubscription
 
     int                         refs;
 
-    // These two are updated by the connection in natsConn_processMsg.
-    // 'msgs' is used to determine if we have reached the max (if > 0).
-    uint64_t                    msgs;
-    uint64_t                    bytes;
-
     // This is non-zero when auto-unsubscribe is used.
     uint64_t                    max;
 

--- a/src/pub.c
+++ b/src/pub.c
@@ -57,10 +57,6 @@ _publishEx(natsConnection *nc, const char *subj,
     {
         s = nats_setDefaultError(NATS_CONNECTION_CLOSED);
     }
-    else if ((s == NATS_OK) && (nc->err != NATS_OK))
-    {
-        s = nats_setError(nc->err, "%s", nc->errStr);
-    }
 
     if (s == NATS_OK)
     {
@@ -134,10 +130,6 @@ _publishEx(natsConnection *nc, const char *subj,
     {
         nc->stats.outMsgs  += 1;
         nc->stats.outBytes += dataLen;
-    }
-    else
-    {
-        nc->err = s;
     }
 
     natsConn_Unlock(nc);


### PR DESCRIPTION
Also ported some of the changes from GO client
- Pending buffer created before the doReconnect thread is started.
- Revisited the use of nc->err to limit it to report async errors.
- Publish and Flush will no longer fail if an async error occurs.
- Ensure flusher is not reseting nc->err on buffer flush success.
- Removed double pending msg accounting.
- Tests updated.