### PR TITLE
Fix unexpected drop of messages by subscribers

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -31,7 +31,7 @@ const char  *name   = "worker";
 int64_t     total   = 1000000;
 
 volatile int64_t count   = 0;
-volatile int     dropped = 0;
+volatile int64_t dropped = 0;
 int64_t          start   = 0;
 volatile int64_t elapsed = 0;
 bool             print   = false;
@@ -47,7 +47,7 @@ printStats(int mode, natsConnection *conn, natsSubscription *sub,
 {
     natsStatus  s = NATS_OK;
     uint64_t    inMsgs, inBytes, outMsgs, outBytes, reconnected;
-    int         pending, delivered, dropped;
+    int64_t     pending, delivered, dropped = 0;
 
     s = natsConnection_GetStats(conn, stats);
     if (s == NATS_OK)
@@ -82,9 +82,9 @@ printStats(int mode, natsConnection *conn, natsSubscription *sub,
         }
         if (mode & STATS_COUNT)
         {
-            printf("Delivered: %9d - ", delivered);
-            printf("Pending: %5d - ", pending);
-            printf("Dropped: %5d - ", dropped);
+            printf("Delivered: %9" PRId64 " - ", delivered);
+            printf("Pending: %5" PRId64 " - ", pending);
+            printf("Dropped: %5" PRId64 " - ", dropped);
         }
         printf("Reconnected: %3" PRIu64 "\n", reconnected);
     }

--- a/examples/replier.c
+++ b/examples/replier.c
@@ -40,7 +40,7 @@ asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure
     if (print)
         printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
 
-    natsSubscription_GetDropped(sub, (int*) &dropped);
+    natsSubscription_GetDropped(sub, (int64_t*) &dropped);
 }
 
 int main(int argc, char **argv)

--- a/examples/subscriber.c
+++ b/examples/subscriber.c
@@ -33,7 +33,7 @@ asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure
     if (print)
         printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
 
-    natsSubscription_GetDropped(sub, (int*) &dropped);
+    natsSubscription_GetDropped(sub, (int64_t*) &dropped);
 }
 
 int main(int argc, char **argv)

--- a/src/nats.h
+++ b/src/nats.h
@@ -1549,7 +1549,7 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs);
  * @param bytesLimit the limit in bytes that the subscription can hold.
  */
 NATS_EXTERN natsStatus
-natsSubscription_SetPendingLimits(natsSubscription *sub, int msgLimit, int bytesLimit);
+natsSubscription_SetPendingLimits(natsSubscription *sub, int64_t msgLimit, int64_t bytesLimit);
 
 /** \brief Returns the current limit for pending messages and bytes.
  *
@@ -1571,7 +1571,7 @@ natsSubscription_SetPendingLimits(natsSubscription *sub, int msgLimit, int bytes
  * size of pending messages for this subscription.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetPendingLimits(natsSubscription *sub, int *msgLimit, int *bytesLimit);
+natsSubscription_GetPendingLimits(natsSubscription *sub, int64_t *msgLimit, int64_t *bytesLimit);
 
 /** \brief Returns the number of pending messages and bytes.
  *
@@ -1588,7 +1588,7 @@ natsSubscription_GetPendingLimits(natsSubscription *sub, int *msgLimit, int *byt
  * pending messages.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetPending(natsSubscription *sub, int *msgs, int *bytes);
+natsSubscription_GetPending(natsSubscription *sub, int64_t *msgs, int64_t *bytes);
 
 /** \brief Returns the number of delivered messages.
  *
@@ -1599,7 +1599,7 @@ natsSubscription_GetPending(natsSubscription *sub, int *msgs, int *bytes);
  * delivered messages.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetDelivered(natsSubscription *sub, int *msgs);
+natsSubscription_GetDelivered(natsSubscription *sub, int64_t *msgs);
 
 /** \brief Returns the number of dropped messages.
  *
@@ -1617,7 +1617,7 @@ natsSubscription_GetDelivered(natsSubscription *sub, int *msgs);
  * @param msgs the memory location where to store the number of dropped messages.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetDropped(natsSubscription *sub, int *msgs);
+natsSubscription_GetDropped(natsSubscription *sub, int64_t *msgs);
 
 /** \brief Returns the maximum number of pending messages and bytes.
  *
@@ -1632,7 +1632,7 @@ natsSubscription_GetDropped(natsSubscription *sub, int *msgs);
  * number of bytes pending seen so far.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetMaxPending(natsSubscription *sub, int *msgs, int *bytes);
+natsSubscription_GetMaxPending(natsSubscription *sub, int64_t *msgs, int64_t *bytes);
 
 /** \brief Clears the statistics regarding the maximum pending values.
  *
@@ -1671,12 +1671,12 @@ natsSubscription_ClearMaxPending(natsSubscription *sub);
  */
 NATS_EXTERN natsStatus
 natsSubscription_GetStats(natsSubscription *sub,
-                          int *pendingMsgs,
-                          int *pendingBytes,
-                          int *maxPendingMsgs,
-                          int *maxPendingBytes,
-                          int *deliveredMsgs,
-                          int *droppedMsgs);
+                          int64_t *pendingMsgs,
+                          int64_t *pendingBytes,
+                          int64_t *maxPendingMsgs,
+                          int64_t *maxPendingBytes,
+                          int64_t *deliveredMsgs,
+                          int64_t *droppedMsgs);
 
 /** \brief Checks the validity of the subscription.
  *

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -169,8 +169,8 @@ typedef struct __natsMsgList
 {
     natsMsg     *head;
     natsMsg     *tail;
-    int         msgs;
-    int         bytes;
+    int64_t     msgs;
+    int64_t     bytes;
 
 } natsMsgList;
 
@@ -252,11 +252,11 @@ struct __natsSubscription
     void                        *msgCbClosure;
 
     // Pending limits, etc..
-    int                         msgsMax;
-    int                         bytesMax;
-    int                         msgsLimit;
-    int                         bytesLimit;
-    int                         dropped;
+    int64_t                     msgsMax;
+    int64_t                     bytesMax;
+    int64_t                     msgsLimit;
+    int64_t                     bytesLimit;
+    int64_t                     dropped;
 
 };
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -257,7 +257,7 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
     sub->msgCbClosure   = cbClosure;
     sub->noDelay        = noDelay;
     sub->msgsLimit      = nc->opts->maxPendingMsgs;
-    sub->bytesLimit     = nc->opts->maxPendingMsgs * 1024;
+    sub->bytesLimit     = sub->msgsLimit * 1024;
     sub->signalLimit    = (int)(sub->msgsLimit * 0.75);
 
     sub->subject = NATS_STRDUP(subj);
@@ -585,7 +585,7 @@ natsStatus
 natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
 {
     natsStatus  s;
-    int         msgs = 0;
+    int64_t     msgs = 0;
 
     if (queuedMsgs == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -598,7 +598,7 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
 }
 
 natsStatus
-natsSubscription_GetPending(natsSubscription *sub, int *msgs, int *bytes)
+natsSubscription_GetPending(natsSubscription *sub, int64_t *msgs, int64_t *bytes)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -623,7 +623,7 @@ natsSubscription_GetPending(natsSubscription *sub, int *msgs, int *bytes)
 }
 
 natsStatus
-natsSubscription_SetPendingLimits(natsSubscription *sub, int msgLimit, int bytesLimit)
+natsSubscription_SetPendingLimits(natsSubscription *sub, int64_t msgLimit, int64_t bytesLimit)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -648,7 +648,7 @@ natsSubscription_SetPendingLimits(natsSubscription *sub, int msgLimit, int bytes
 }
 
 natsStatus
-natsSubscription_GetPendingLimits(natsSubscription *sub, int *msgLimit, int *bytesLimit)
+natsSubscription_GetPendingLimits(natsSubscription *sub, int64_t *msgLimit, int64_t *bytesLimit)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -673,7 +673,7 @@ natsSubscription_GetPendingLimits(natsSubscription *sub, int *msgLimit, int *byt
 }
 
 natsStatus
-natsSubscription_GetDelivered(natsSubscription *sub, int *msgs)
+natsSubscription_GetDelivered(natsSubscription *sub, int64_t *msgs)
 {
     if ((sub == NULL) || (msgs == NULL))
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -686,7 +686,7 @@ natsSubscription_GetDelivered(natsSubscription *sub, int *msgs)
         return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
     }
 
-    *msgs = (int) sub->delivered;
+    *msgs = (int64_t) sub->delivered;
 
     natsSub_Unlock(sub);
 
@@ -694,7 +694,7 @@ natsSubscription_GetDelivered(natsSubscription *sub, int *msgs)
 }
 
 natsStatus
-natsSubscription_GetDropped(natsSubscription *sub, int *msgs)
+natsSubscription_GetDropped(natsSubscription *sub, int64_t *msgs)
 {
     if ((sub == NULL) || (msgs == NULL))
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -707,7 +707,7 @@ natsSubscription_GetDropped(natsSubscription *sub, int *msgs)
         return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
     }
 
-    *msgs = (int) sub->dropped;
+    *msgs = sub->dropped;
 
     natsSub_Unlock(sub);
 
@@ -715,7 +715,7 @@ natsSubscription_GetDropped(natsSubscription *sub, int *msgs)
 }
 
 natsStatus
-natsSubscription_GetMaxPending(natsSubscription *sub, int *msgs, int *bytes)
+natsSubscription_GetMaxPending(natsSubscription *sub, int64_t *msgs, int64_t *bytes)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -763,12 +763,12 @@ natsSubscription_ClearMaxPending(natsSubscription *sub)
 
 natsStatus
 natsSubscription_GetStats(natsSubscription *sub,
-        int *pendingMsgs,
-        int *pendingBytes,
-        int *maxPendingMsgs,
-        int *maxPendingBytes,
-        int *deliveredMsgs,
-        int *droppedMsgs)
+        int64_t *pendingMsgs,
+        int64_t *pendingBytes,
+        int64_t *maxPendingMsgs,
+        int64_t *maxPendingBytes,
+        int64_t *deliveredMsgs,
+        int64_t *droppedMsgs)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);

--- a/test/test.c
+++ b/test/test.c
@@ -6765,10 +6765,10 @@ test_PendingLimitsDeliveredAndDropped(void)
     natsPid             serverPid = NATS_INVALID_PID;
     int                 total     = 100;
     int                 sent      = total + 20;
-    int                 msgsLimit = 0;
-    int                 bytesLimit= 0;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgsLimit = 0;
+    int64_t             bytesLimit= 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
     struct threadArg    arg;
 
     s = _createDefaultThreadArgsForCbTests(&arg);
@@ -6969,10 +6969,10 @@ test_PendingLimitsWithSyncSub(void)
     natsSubscription    *sub      = NULL;
     natsMsg             *msg      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
-    int                 msgsLimit = 0;
-    int                 bytesLimit= 0;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgsLimit = 0;
+    int64_t             bytesLimit= 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
 
     serverPid = _startServer(NATS_DEFAULT_URL, NULL, true);
     CHECK_SERVER_STARTED(serverPid);
@@ -7040,8 +7040,8 @@ test_AsyncSubscriptionPending(void)
     natsSubscription    *sub      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     int                 total     = 100;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
     int                 mlen      = 10;
     int                 totalSize = total * mlen;
     uint64_t            queuedMsgs= 0;
@@ -7150,8 +7150,8 @@ test_AsyncSubscriptionPendingDrain(void)
     natsSubscription    *sub      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     int                 total     = 100;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
     int                 mlen      = 10;
     int                 totalSize = total * mlen;
     uint64_t            queuedMsgs= 0;
@@ -7220,8 +7220,8 @@ test_SyncSubscriptionPending(void)
     natsSubscription    *sub      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     int                 total     = 100;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
     int                 mlen      = 10;
     int                 totalSize = total * mlen;
     uint64_t            queuedMsgs= 0;
@@ -7311,8 +7311,8 @@ test_SyncSubscriptionPendingDrain(void)
     natsSubscription    *sub      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     int                 total     = 100;
-    int                 msgs      = 0;
-    int                 bytes     = 0;
+    int64_t             msgs      = 0;
+    int64_t             bytes     = 0;
     int                 i;
 
     serverPid = _startServer(NATS_DEFAULT_URL, NULL, true);


### PR DESCRIPTION
Some of the new limits and counters introduced in 1.3 were defined
as int, which would cause overflow when the number of messages was
high. Changed types to int64_t.