### PR TITLE
[FIXED] Connect to server listening to IPv4 if host resolves to IPv6

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -17,6 +17,7 @@ natsHashing
 natsStrHash
 natsInbox
 natsOptions
+natsSock_ConnectTcp
 natsSock_ReadLine
 natsJSON
 ReconnectServerStats

--- a/test/test.c
+++ b/test/test.c
@@ -2860,6 +2860,24 @@ _startServer(const char *url, const char *cmdLineOpts, bool checkStart)
 }
 #endif
 
+static void
+test_natsSock_ConnectTcp(void)
+{
+    natsPid     serverPid = NATS_INVALID_PID;
+
+    test("Check connect tcp: ");
+    serverPid = _startServer("nats://localhost:4222", "-p 4222", true);
+    testCond(serverPid != NATS_INVALID_PID);
+    _stopServer(serverPid);
+    serverPid = NATS_INVALID_PID;
+
+    test("Check connect tcp (force server to listen to IPv4): ");
+    serverPid = _startServer("nats://localhost:4222", "-a 127.0.0.1 -p 4222", true);
+    testCond(serverPid != NATS_INVALID_PID);
+    _stopServer(serverPid);
+    serverPid = NATS_INVALID_PID;
+}
+
 static natsOptions*
 _createReconnectOptions(void)
 {
@@ -10671,6 +10689,7 @@ static testInfo allTests[] =
     {"natsStrHash",                     test_natsStrHash},
     {"natsInbox",                       test_natsInbox},
     {"natsOptions",                     test_natsOptions},
+    {"natsSock_ConnectTcp",             test_natsSock_ConnectTcp},
     {"natsSock_ReadLine",               test_natsSock_ReadLine},
     {"natsJSON",                        test_natsJSON},
 


### PR DESCRIPTION
We were trying IPv6 addresses but would not try IPv4 if we
got IPv6 addresses but could not connect, for instance because
the server was accepting connections on IPv4 address only.