### PR TITLE
allow disabling of monotonic clock as JRuby FFI thinks it exposes and…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(NATS_BUILD_WITH_TLS "Build with TLS support" ON)
 option(NATS_BUILD_WITH_TLS_CLIENT_METHOD "Use TLS_client_method()" OFF)
 option(NATS_BUILD_LIBUV_EXAMPLE "Compile libuv example" OFF)
 option(NATS_BUILD_LIBEVENT_EXAMPLE "Compile libevent example" OFF)
+option(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC "Compile without respecting CLOCK_MONOTONIC" OFF)
 
 if(NATS_BUILD_WITH_TLS)
 find_package(OpenSSL REQUIRED)
@@ -84,6 +85,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NATS_CODE_COVERAGE} ${NATS_COMMON_C_FLAGS}
 
 add_definitions(-D${NATS_OS})
 add_definitions(-D_REENTRANT)
+if(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC)
+add_definitions(-DNATS_NO_CLOCK_MONOTONIC)
+endif(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC)
 if(NATS_BUILD_WITH_TLS)
 add_definitions(-DNATS_HAS_TLS)
 if(NATS_BUILD_WITH_TLS_CLIENT_METHOD)

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -14,7 +14,7 @@ nats_Now(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm);
-#elif defined CLOCK_MONOTONIC
+#elif !defined NATS_NO_CLOCK_MONOTONIC && defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();
@@ -34,7 +34,7 @@ nats_NowInNanoSeconds(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm) * 1000000L;
-#elif defined CLOCK_MONOTONIC
+#elif !defined NATS_NO_CLOCK_MONOTONIC && defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();


### PR DESCRIPTION
… it does not

in writing an FFI bridge into cnats (as opposed to using EventMachine with Ruby) I came across inconsistencies in how different Rubies (JRuby and MRI in this case) expose `CLOCK_MONOTONIC` to their respective implementations of FFI

am able to build and use the shared library on both when compiling and just shutting off `CLOCK_MONOTONIC` from the cnats side

Still building out bridge, but mostly working examples using cnats and getting a compile flag to take out `CLOCK_MONOTONIC` would certainly help in cross-ruby support
(https://github.com/abrandoned/cnats/blob/abrandoned/no_monotonic_clock/natsffi.rb)