### PR TITLE
[FIXED] Crash if linked to dynamic NATS lib no NATS API call is made

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,5 +136,6 @@ endif()
 add_subdirectory(src)
 add_subdirectory(examples)
 add_subdirectory(test)
+add_subdirectory(test/dylib)
 #----------------------------
 

--- a/buildOnTravis.sh
+++ b/buildOnTravis.sh
@@ -29,6 +29,12 @@ if [ $res -ne 0 ]; then
   exit $res
 fi
 
+echo "Test app using dynamic library does not crash if no NATS call is made"
+test/dylib/nonats
+res=$?
+if [ $res -ne 0 ]; then
+  exit $res
+fi
 ctest --timeout 60 --output-on-failure $4
 res=$?
 if [ $res -ne 0 ]; then

--- a/src/nats.c
+++ b/src/nats.c
@@ -189,6 +189,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, // DLL module handle
         case DLL_THREAD_DETACH:
         case DLL_PROCESS_DETACH:
         {
+            if (!(gLib.wasOpenedOnce))
+                break;
+
             _cleanupThreadLocals();
 
             if (fdwReason == DLL_PROCESS_DETACH)

--- a/test/dylib/CMakeLists.txt
+++ b/test/dylib/CMakeLists.txt
@@ -1,0 +1,10 @@
+# We need this to build the test program
+include_directories(${PROJECT_SOURCE_DIR}/src)
+
+# Build the test program
+add_executable(nonats nonats.c)
+
+# Link dynamically with the library
+add_definitions(-Dnats_IMPORTS)
+
+target_link_libraries(nonats nats ${NATS_EXTRA_LIB})

--- a/test/dylib/nonats.c
+++ b/test/dylib/nonats.c
@@ -1,0 +1,13 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+#include <nats.h>
+
+int main(int argc, char **argv)
+{
+    // Give a chance for the destructor/DllMain to be registered.
+    // Note that nats_Sleep() is not "opening" the library, so
+    // the cleanup code would still crash if we were not skipping
+    // the cleanup if we detect that library was never oepened.
+    nats_Sleep(1000);
+    return 0;
+}


### PR DESCRIPTION
Specific to Windows (since it was previously fixed for other platforms).
This happens only when linking against the dynamic library and if
no call to NATS is made. Calling explicitly nats_Open()/nats_Close()
would prevent this crash from happening.

Resolves #54