### PR TITLE
[FIXED] Crash in _updateStack (index out of range)

### DIFF
--- a/src/nats.c
+++ b/src/nats.c
@@ -1178,6 +1178,7 @@ _updateStack(natsTLError *errTL, const char *funcName, natsStatus errSts,
 
     idx = errTL->framesCount;
     if ((idx >= 0)
+        && (idx < MAX_FRAMES)
         && (strcmp(errTL->func[idx], funcName) == 0))
     {
         return;


### PR DESCRIPTION
Happens when application keeps reconnecting (e.g. maxReconnect=-1) and  errTL->func is filled with "natsConnection_FlushTimeout"/"natsConnection_Flush" sequences.