### PR TITLE
[FIXED] Prevent error stack growth when Flush()/FlushTimeout fails

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2413,6 +2413,10 @@ natsConnection_FlushTimeout(natsConnection *nc, int64_t timeout)
             // If we are here, it is possible that we timed-out, or some other
             // error occurred. Make sure the request is no longer in the list.
             _removePongFromList(nc, pong);
+
+            // Set the error. If we don't do that, and flush is called in a loop,
+            // the stack would be growing with Flush/FlushTimeout.
+            s = nats_setDefaultError(s);
         }
 
         // We are done with the pong


### PR DESCRIPTION
This is in relation to PR #56 that fixed the crash when error stack
grows too big. The issue was discovered due to Flush() call failures
that repeated a number of times would make the error stack grow.