### PR TITLE
State the documentation link near the top of the readme [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # NATS - C Client 
 A C client for the [NATS messaging system](https://nats.io).
 
+Go [here](http://nats-io.github.io/cnats) for the online documentation.
+
 This NATS Client implementation is heavily based on the [NATS GO Client](https://github.com/nats-io/nats). There is support for Mac OS/X, Linux and Windows (although we don't have specific platform support matrix).
 
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
I kept having to scroll around to find the docs link, usually it's at the very top. It may save some people a little time.