### PR TITLE
Add missing librt on linux via NATS_EXTRA_LIB var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ option(NATS_BUILD_WITH_TLS "Build with TLS support" ON)
 option(NATS_BUILD_WITH_TLS_CLIENT_METHOD "Use TLS_client_method()" OFF)
 option(NATS_BUILD_LIBUV_EXAMPLE "Compile libuv example" OFF)
 option(NATS_BUILD_LIBEVENT_EXAMPLE "Compile libevent example" OFF)
-option(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC "Compile without respecting CLOCK_MONOTONIC" OFF)
 
 if(NATS_BUILD_WITH_TLS)
 find_package(OpenSSL REQUIRED)
@@ -85,9 +84,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NATS_CODE_COVERAGE} ${NATS_COMMON_C_FLAGS}
 
 add_definitions(-D${NATS_OS})
 add_definitions(-D_REENTRANT)
-if(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC)
-add_definitions(-DNATS_NO_CLOCK_MONOTONIC)
-endif(NATS_BUILD_WITHOUT_CLOCK_MONOTONIC)
 if(NATS_BUILD_WITH_TLS)
 add_definitions(-DNATS_HAS_TLS)
 if(NATS_BUILD_WITH_TLS_CLIENT_METHOD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(NATS_OPENSSL_LIBS "${OPENSSL_LIBRARIES}")
 endif(NATS_BUILD_WITH_TLS)
 
 #---------------------------------------
-# Grab all files in 'src' and 'src/unix' 
+# Grab all files in 'src' and 'src/unix'
 # or 'src/win' depending on the platform
 #---------------------------------------
 file(GLOB SOURCES "*.c")
@@ -17,11 +17,11 @@ file(GLOB PS_SOURCES "${NATS_PLATFORM_INCLUDE}/*.c")
 
 # --------------------------------------
 # Create the shared and static libraries
-# -------------------------------------- 
+# --------------------------------------
 add_library(nats SHARED ${SOURCES} ${PS_SOURCES})
-target_link_libraries(nats ${NATS_OPENSSL_LIBS})
+target_link_libraries(nats ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB})
 add_library(nats_static STATIC ${SOURCES} ${PS_SOURCES})
-target_link_libraries(nats_static ${NATS_OPENSSL_LIBS})
+target_link_libraries(nats_static ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB})
 
 # --------------------------------------
 # Install the libraries and header files
@@ -29,4 +29,3 @@ target_link_libraries(nats_static ${NATS_OPENSSL_LIBS})
 install(TARGETS nats DESTINATION lib)
 install(TARGETS nats_static DESTINATION lib)
 install(FILES nats.h status.h version.h DESTINATION include)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB PS_SOURCES "${NATS_PLATFORM_INCLUDE}/*.c")
 add_library(nats SHARED ${SOURCES} ${PS_SOURCES})
 target_link_libraries(nats ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB})
 add_library(nats_static STATIC ${SOURCES} ${PS_SOURCES})
-target_link_libraries(nats_static ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB})
+target_link_libraries(nats_static ${NATS_OPENSSL_LIBS})
 
 # --------------------------------------
 # Install the libraries and header files

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -14,7 +14,7 @@ nats_Now(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm);
-#elif !defined NATS_NO_CLOCK_MONOTONIC && defined CLOCK_MONOTONIC
+#elif defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();
@@ -34,7 +34,7 @@ nats_NowInNanoSeconds(void)
     struct _timeb now;
     _ftime_s(&now);
     return (((int64_t)now.time) * 1000 + now.millitm) * 1000000L;
-#elif !defined NATS_NO_CLOCK_MONOTONIC && defined CLOCK_MONOTONIC
+#elif defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         abort();


### PR DESCRIPTION
I was working on loading cnats via the ffi gem with jruby and noticed that I was having issues loading libnats because...
```
libnats.so: undefined symbol: clock_gettime.
```
This loads just fine under MRI.

I noticed we set the `NATS_EXTRA_LIB` var in the main `CMakeLists.txt` and that we use it for tests, but we we're not using it in `src/CMakeLists.txt`. Adding it back fixes the problem.

Here's a failing job in travis: https://travis-ci.org/abrandoned/protobuf-nats/jobs/218995507#L761