### PR TITLE
Reduce risk of server closing conn (slow consumer) if sending to itself

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2017 Apcera Inc. All rights reserved.
 
 #ifndef CONN_H_
 #define CONN_H_
@@ -67,7 +67,7 @@ natsStatus
 natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max);
 
 void
-natsConn_removeSubscription(natsConnection *nc, natsSubscription *sub, bool needsLock);
+natsConn_removeSubscription(natsConnection *nc, natsSubscription *sub);
 
 void
 natsConn_processAsyncINFO(natsConnection *nc, char *buf, int len);

--- a/src/nats.c
+++ b/src/nats.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Apcera Inc. All rights reserved.
+// Copyright 2015-2017 Apcera Inc. All rights reserved.
 
 #include "natsp.h"
 
@@ -1555,7 +1555,7 @@ _deliverMsgs(void *arg)
         if ((max > 0) && (delivered >= max))
         {
             // If we have hit the max for delivered msgs, remove sub.
-            natsConn_removeSubscription(nc, sub, true);
+            natsConn_removeSubscription(nc, sub);
         }
 
         natsMutex_Lock(dlv->lock);

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Apcera Inc. All rights reserved.
+// Copyright 2015-2017 Apcera Inc. All rights reserved.
 
 #ifndef NATSP_H_
 #define NATSP_H_
@@ -347,6 +347,7 @@ struct __natsConnection
 
     int64_t             ssid;
     natsHash            *subs;
+    natsMutex           *subsMu;
 
     natsConnStatus      status;
     natsStatus          err;

--- a/src/sub.c
+++ b/src/sub.c
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2017 Apcera Inc. All rights reserved.
 
 #include "natsp.h"
 
@@ -176,7 +176,7 @@ natsSub_deliverMsgs(void *arg)
         if ((max > 0) && (delivered >= max))
         {
             // If we have hit the max for delivered msgs, remove sub.
-            natsConn_removeSubscription(nc, sub, true);
+            natsConn_removeSubscription(nc, sub);
             break;
         }
     }
@@ -586,7 +586,7 @@ natsSubscription_NextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeo
     natsSub_Unlock(sub);
 
     if (removeSub)
-        natsConn_removeSubscription(nc, sub, true);
+        natsConn_removeSubscription(nc, sub);
 
     return NATS_UPDATE_ERR_STACK(s);
 }


### PR DESCRIPTION
When a client sends data and has at least a matching subscriber,
there may be a case where the flusher is holding the connection's
lock while trying to flush the write buffer, which cannot complete
because the server is not draining data at the moment since it is
itself trying to send data to the client, which processMsg() function
is waiting on the connection's lock. After 2 seconds, the server
will close the client connection.
Using a dedicated lock for the subscriptions map that processMsg
needs to access is reducing the risk of lock contention between
publish/flusher and the readloop's processMsg function.
There would still be a case where if the subscription in the client
is considered a slow consumer and messages are dropped, we need to
acquire the connection lock there. But in cases where subscribers
keep up, we would reduce the risk of server's slow consumer error.