### PR TITLE
[FIXED] Permissions violation handling

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -65,6 +65,7 @@
 #define _UNSUB_NO_MAX_PROTO_ "UNSUB %" PRId64 " \r\n"
 
 #define STALE_CONNECTION     "Stale Connection"
+#define PERMISSIONS_ERR      "Permissions Violation"
 
 #define _CRLF_LEN_          (2)
 #define _SPC_LEN_           (1)

--- a/test/list.txt
+++ b/test/list.txt
@@ -59,6 +59,7 @@ ErrOnMaxPayloadLimit
 Auth
 AuthFailNoDisconnectCB
 AuthToken
+PermViolation
 ConnectedServer
 MultipleClose
 SimplePublish

--- a/test/permissions.conf
+++ b/test/permissions.conf
@@ -1,0 +1,12 @@
+authorization {
+  users = [
+    {
+		user: ivan
+		password: pwd
+     	permissions: {
+    		publish="foo"
+    		subscribe="bar"
+     	}
+	}
+  ]
+}


### PR DESCRIPTION
If the application publishes or subscribes to a subject for which
the user does not have proper permissions, the client library
receives an error from the server. This needs to be handled properly
otherwise the connection ends-up being closed.
The library will now invoke the error handler if one is set.