### PR TITLE
[CHANGED] Added nats to the include directory during install [ci skip]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ endif(NATS_BUILD_WITH_TLS)
 #---------------------------------------------------------------------
 # Add to the 'clean' target the list (and location) of files to remove
 
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats.h")
 list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/nats.h")
 list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/status.h")
 list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/version.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,9 +94,11 @@ endif(NATS_BUILD_WITH_TLS)
 #---------------------------------------------------------------------
 # Add to the 'clean' target the list (and location) of files to remove
 
-list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats.h")
-list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/status.h")
-list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/version.h")
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/nats.h")
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/status.h")
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/version.h")
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/adapters/libevent.h")
+list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/include/nats/adapters/libuv.h")
 list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/lib/${nats}")
 list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/lib/${nats_static}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,5 +28,5 @@ target_link_libraries(nats_static ${NATS_OPENSSL_LIBS})
 # --------------------------------------
 install(TARGETS nats DESTINATION lib)
 install(TARGETS nats_static DESTINATION lib)
-install(FILES nats.h status.h version.h DESTINATION include)
-install(FILES adapters/libevent.h adapters/libuv.h DESTINATION include/adapters)
+install(FILES nats.h status.h version.h DESTINATION include/nats)
+install(FILES adapters/libevent.h adapters/libuv.h DESTINATION include/nats/adapters)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,5 +28,6 @@ target_link_libraries(nats_static ${NATS_OPENSSL_LIBS})
 # --------------------------------------
 install(TARGETS nats DESTINATION lib)
 install(TARGETS nats_static DESTINATION lib)
+install(FILES deprnats.h DESTINATION include RENAME nats.h)
 install(FILES nats.h status.h version.h DESTINATION include/nats)
 install(FILES adapters/libevent.h adapters/libuv.h DESTINATION include/nats/adapters)

--- a/src/deprnats.h
+++ b/src/deprnats.h
@@ -1,0 +1,14 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+
+#ifndef SRC_DEPRNATS_H_
+#define SRC_DEPRNATS_H_
+
+#ifndef _WIN32
+#warning "`#include <nats.h>` is deprecated. Please use `#include <nats/nats.h>`"
+#else
+#pragma message ("`#include <nats.h>` is deprecated. Please use `#include <nats/nats.h>`")
+#endif
+
+#include <nats/nats.h>
+
+#endif /* SRC_DEPRNATS_H_ */

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -20,7 +20,7 @@ extern "C" {
                              (NATS_VERSION_MINOR <<  8) | \
                              NATS_VERSION_PATCH)
                              
-#define NATS_VERSION_REQUIRED_NUMBER @NATS_VERSION_REQUIRED_NUMBER@                             
+#define NATS_VERSION_REQUIRED_NUMBER @NATS_VERSION_REQUIRED_NUMBER@
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When doing `make install`, the header files are now copied under
the `$CMAKE_INSTALL_PREFIX/include/nats`.

Resolves #72