### PR TITLE
[CHANGED] Authorization violation handling

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -66,6 +66,7 @@
 
 #define STALE_CONNECTION     "Stale Connection"
 #define PERMISSIONS_ERR      "Permissions Violation"
+#define AUTHORIZATION_ERR    "Authorization Violation"
 
 #define _CRLF_LEN_          (2)
 #define _SPC_LEN_           (1)

--- a/test/list.txt
+++ b/test/list.txt
@@ -61,6 +61,7 @@ Auth
 AuthFailNoDisconnectCB
 AuthToken
 PermViolation
+AuthViolation
 ConnectedServer
 MultipleClose
 SimplePublish


### PR DESCRIPTION
When getting an authorization violation after being connected
(will happen with server config reload), the client library will
now report the error if an error handler is set, but will not
close the connection.