### PR TITLE
[ADDED] Support for ARM 6 [ci skip]

### DIFF
--- a/src/unix/mutex.c
+++ b/src/unix/mutex.c
@@ -60,7 +60,7 @@ void
 natsMutex_Lock(natsMutex *m)
 {
     // The "rep" instruction used for spinning is not supported on ARM.
-#ifndef __arm__
+#if !defined(__arm__) && !defined(__aarch64__)
     if (gLockSpinCount > 0)
     {
         int64_t attempts = 0;


### PR DESCRIPTION
Needed to add `__aarch64__` to exclude usage of `rep` in spin lock.

Resolves #87