### PR TITLE
[CHANGED] natsEvLoop_Attach socket parameter type

### DIFF
--- a/src/adapters/libevent.h
+++ b/src/adapters/libevent.h
@@ -80,7 +80,7 @@ keepAliveCb(evutil_socket_t fd, short flags, void * arg)
  * @param socket the socket to start polling on.
  */
 natsStatus
-natsLibevent_Attach(void **userData, void *loop, natsConnection *nc, int socket)
+natsLibevent_Attach(void **userData, void *loop, natsConnection *nc, natsSock socket)
 {
     struct event_base   *libeventLoop = (struct event_base*) loop;
     natsLibeventEvents  *nle          = (natsLibeventEvents*) (*userData);

--- a/src/adapters/libuv.h
+++ b/src/adapters/libuv.h
@@ -37,7 +37,7 @@ typedef struct
     uv_poll_t       *handle;
     uv_async_t      *scheduler;
     int             events;
-    int             socket;
+    natsSock        socket;
     uv_mutex_t      *lock;
     natsLibuvEvent  *head;
     natsLibuvEvent  *tail;
@@ -316,7 +316,7 @@ uvAsyncCb(uv_async_t *handle)
  * @param socket the socket to start polling on.
  */
 natsStatus
-natsLibuv_Attach(void **userData, void *loop, natsConnection *nc, int socket)
+natsLibuv_Attach(void **userData, void *loop, natsConnection *nc, natsSock socket)
 {
     uv_loop_t       *uvLoop = (uv_loop_t*) loop;
     bool            sched   = false;

--- a/src/nats.h
+++ b/src/nats.h
@@ -188,7 +188,7 @@ typedef natsStatus (*natsEvLoop_Attach)(
         void            **userData,
         void            *loop,
         natsConnection  *nc,
-        int             socket);
+        natsSock        socket);
 
 /** \brief Read event needs to be added or removed.
  *


### PR DESCRIPTION
Replaced `int socket` with `natsSock socket`.
Altough there was no warning compiling on Unix or Windows (where
a socket is defined as SOCKET as opposed to int), using natsSock
to be inline with the socket type on various platforms.

Updated the libevent and libuv headers accordingly.