### PR TITLE
[FIXED] Possible missed auto-unsubscribe change under global message delivery

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2391,12 +2391,10 @@ natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max)
         return NATS_OK;
     }
 
-    natsSub_Lock(sub);
-    sub->max = max;
-    natsSub_Unlock(sub);
-
     if (max == 0)
         natsConn_removeSubscription(nc, sub);
+    else
+        natsSub_setMax(sub, max);
 
     if (!natsConn_isReconnecting(nc))
     {

--- a/src/sub.c
+++ b/src/sub.c
@@ -185,6 +185,16 @@ natsSub_deliverMsgs(void *arg)
 }
 
 void
+natsSub_setMax(natsSubscription *sub, uint64_t max)
+{
+    natsSub_Lock(sub);
+    SUB_DLV_WORKER_LOCK(sub);
+    sub->max = max;
+    SUB_DLV_WORKER_UNLOCK(sub);
+    natsSub_Unlock(sub);
+}
+
+void
 natsSub_close(natsSubscription *sub, bool connectionClosed)
 {
     natsMsgDlvWorker *ldw = NULL;

--- a/src/sub.h
+++ b/src/sub.h
@@ -29,6 +29,9 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
                const char *queueGroup, int64_t timeout, natsMsgHandler cb, void *cbClosure);
 
 void
+natsSub_setMax(natsSubscription *sub, uint64_t max);
+
+void
 natsSub_close(natsSubscription *sub, bool connectionClosed);
 
 #endif /* SUB_H_ */


### PR DESCRIPTION
Setting the new max value needed to be protected by the worker's
lock when the subscription is attached to a global message delivery
thread.