### PR TITLE
[FIXED] Windows - Error message not printed if too long

### DIFF
--- a/src/include/n-unix.h
+++ b/src/include/n-unix.h
@@ -53,5 +53,6 @@ typedef size_t          natsRecvLen;
 
 #define nats_asprintf       asprintf
 #define nats_strcasestr     strcasestr
+#define nats_vsnprintf      vsnprintf
 
 #endif /* N_UNIX_H_ */

--- a/src/include/n-win.h
+++ b/src/include/n-win.h
@@ -50,6 +50,8 @@ typedef int                 natsRecvLen;
 #endif
 #define strcasecmp  _stricmp
 
+#define nats_vsnprintf(b, sb, f, a) vsnprintf_s((b), (sb), (_TRUNCATE), (f), (a))
+
 int
 nats_asprintf(char **newStr, const char *fmt, ...);
 

--- a/src/nats.c
+++ b/src/nats.c
@@ -1223,14 +1223,24 @@ nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStat
     errTL->sts = errSts;
     errTL->framesCount = -1;
 
+    tmp[0] = '\0';
+
     va_start(ap, errTxtFmt);
-    n = vsnprintf(tmp, sizeof(tmp), errTxtFmt, ap);
+    nats_vsnprintf(tmp, sizeof(tmp), errTxtFmt, ap);
     va_end(ap);
 
-    if (n > 0)
+    if (strlen(tmp) > 0)
     {
-        snprintf(errTL->text, sizeof(errTL->text), "(%s:%d): %s",
-                 _getErrorShortFileName(fileName), line, tmp);
+        n = snprintf(errTL->text, sizeof(errTL->text), "(%s:%d): %s",
+                     _getErrorShortFileName(fileName), line, tmp);
+        if ((n < 0) || (n >= (int) sizeof(errTL->text)))
+        {
+            int pos = ((int) strlen(errTL->text)) - 1;
+            int i;
+
+            for (i=0; i<3; i++)
+                errTL->text[pos--] = '.';
+        }
     }
 
     _updateStack(errTL, funcName, errSts, true);

--- a/test/list.txt
+++ b/test/list.txt
@@ -21,6 +21,7 @@ natsSock_ConnectTcp
 natsSock_IPOrder
 natsSock_ReadLine
 natsJSON
+natsErrWithLongText
 natsErrStackMoreThanMaxFrames
 ReconnectServerStats
 ParseStateReconnectFunctionality


### PR DESCRIPTION
If the error text that the library wanted to report was too long,
the error string would not be printed at all.
This is now fixed. The text will have `...` at the end to indicate
that it was truncated.