### PR TITLE
[FIXED] Headers for C++ support

### DIFF
--- a/src/adapters/libevent.h
+++ b/src/adapters/libevent.h
@@ -3,6 +3,10 @@
 #ifndef LIBEVENT_H_
 #define LIBEVENT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \cond
  *
  */
@@ -216,5 +220,9 @@ natsLibevent_Detach(void *userData)
 }
 
 /** @} */ // end of libeventFunctions
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBEVENT_H_ */

--- a/src/adapters/libuv.h
+++ b/src/adapters/libuv.h
@@ -3,6 +3,10 @@
 #ifndef LIBUV_H_
 #define LIBUV_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \cond
  *
  */
@@ -468,5 +472,9 @@ natsLibuv_Detach(void *userData)
 }
 
 /** @} */ // end of libuvFunctions
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBUV_H_ */

--- a/src/nats.h
+++ b/src/nats.h
@@ -3,6 +3,10 @@
 #ifndef NATS_H_
 #define NATS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -33,10 +37,6 @@
 #else
   #define NATS_EXTERN
   typedef int         natsSock;
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /*! \mainpage %NATS C client.


### PR DESCRIPTION
Some newer headers (the adapters) did not have the block allowing
those headers to be used in C++

Resolves #109