### PR TITLE
[FIXED] Use uv_poll_init_socket for libuv <= 1.x [ci skip]

### DIFF
--- a/src/adapters/libuv.h
+++ b/src/adapters/libuv.h
@@ -194,10 +194,14 @@ uvAsyncAttach(natsLibuvEvents *nle)
     if (nle->handle == NULL)
         s = NATS_NO_MEMORY;
 
-    if ((s == NATS_OK)
-        && (uv_poll_init(nle->loop, nle->handle, nle->socket) != 0))
+    if (s == NATS_OK)
     {
-        s = NATS_ERR;
+#if UV_VERSION_MAJOR <= 1
+        if (uv_poll_init_socket(nle->loop, nle->handle, nle->socket) != 0)
+#else
+        if (uv_poll_init(nle->loop, nle->handle, nle->socket) != 0)
+#endif
+            s = NATS_ERR;
     }
 
     if ((s == NATS_OK)


### PR DESCRIPTION
In libuv version prior to 2.0 (master), there is an API called
uv_poll_init_socket() that accepts a socket as last argument.
The uv_poll_init is doing some conversion and then call
uv_poll_init_socket, which can cause some issues for some users
on Windows platforms.

Starting libuv 2.0 (master), the uv_poll_init_socket API is renamed
as simply uv_poll_init (the two are consolidated).

The libuv adapter is therefore modified to use uv_poll_init_socket
if using the libuv 1.x version, and uv_poll_init otherwise.

Resolves #98