### PR TITLE
glibc 2.26 support FIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(WIN32)
 endif(UNIX)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NATS_CODE_COVERAGE} ${NATS_COMMON_C_FLAGS} ${NATS_USE_PTHREAD} ${NATS_WARNINGS}")
-
+add_definitions(-D_GNU_SOURCE)
 add_definitions(-D${NATS_OS})
 add_definitions(-D_REENTRANT)
 if(NATS_BUILD_WITH_TLS)

--- a/src/include/n-unix.h
+++ b/src/include/n-unix.h
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <netinet/in.h>
-#include <xlocale.h>
+#include <locale.h>
 
 typedef pthread_t       natsThread;
 typedef pthread_key_t   natsThreadLocal;


### PR DESCRIPTION
There is a problem with glibc 2.26 compilation. 

They removed xlocale.h support since this version. 
https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27
This fix works only for linux and may be must be changed to make support of all other platforms. 