### PR TITLE
[IMPROVED] Server pool is updated following cluster updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
     - valgrind
     - libssl-dev
     - unzip
-#    - libc6-dev-i386
 
 before_install:
   - bash install_gnatsd.sh

--- a/buildOnTravis.sh
+++ b/buildOnTravis.sh
@@ -35,6 +35,7 @@ res=$?
 if [ $res -ne 0 ]; then
   exit $res
 fi
+export NATS_TEST_SERVER_VERSION="$(gnatsd -v)"
 env NATS_TEST_TRAVIS=yes ctest --timeout 60 --output-on-failure $4
 res=$?
 if [ $res -ne 0 ]; then

--- a/src/conn.c
+++ b/src/conn.c
@@ -510,14 +510,18 @@ _processInfo(natsConnection *nc, char *info, int len)
             (int) nc->info.maxPayload);
 #endif
 
-    if (s == NATS_OK)
+    // The array could be empty/not present on initial connect,
+    // if advertise is disabled on that server, or servers that
+    // did not include themselves in the async INFO protocol.
+    // If empty, do not remove the implicit servers from the pool.
+    if ((s == NATS_OK) && (nc->info.connectURLsCount > 0))
     {
         bool added = false;
 
         s = natsSrvPool_addNewURLs(nc->srvPool,
+                                   nc->url,
                                    nc->info.connectURLs,
                                    nc->info.connectURLsCount,
-                                   !nc->opts->noRandomize,
                                    &added);
         if ((s == NATS_OK) && added && !nc->initc && (nc->opts->discoveredServersCb != NULL))
             natsAsyncCb_PostConnHandler(nc, ASYNC_DISCOVERED_SERVERS);

--- a/src/srvpool.h
+++ b/src/srvpool.h
@@ -66,9 +66,9 @@ natsSrv*
 natsSrvPool_GetNextServer(natsSrvPool *pool, struct __natsOptions *opts, const natsUrl *ncUrl);
 
 // Go through the list of the given URLs and add them to the pool if not already
-// present. If `doShuffle` is true, shuffles the pool if new URLs were added.
+// present.
 natsStatus
-natsSrvPool_addNewURLs(natsSrvPool *pool, char **urls, int urlCount, bool doShuffle, bool *added);
+natsSrvPool_addNewURLs(natsSrvPool *pool, const natsUrl *curUrl, char **urls, int urlCount, bool *added);
 
 // Returns an array of servers (as a copy). User is responsible to free the memory.
 natsStatus

--- a/test/list.txt
+++ b/test/list.txt
@@ -134,3 +134,4 @@ GetServers
 GetDiscoveredServers
 DiscoveredServersCb
 INFOAfterFirstPONGisProcessedOK
+ServerPoolUpdatedOnClusterUpdate


### PR DESCRIPTION
The server pool was only growing when new servers were discovered.
Now, the client library updates its server pool based on server's
INFO protocols (true for server 1.0.6+).
The DiscoveredServersCB is still invoked only when new servers
are added (as in never seen as opposed to added back after leaving
the cluster).

Test has been running with local server at 1.0.7. The test will
not be active until executable is avail for download/install
on Travis.

Resolves #130