### PR TITLE
[IMPROVED] No Flusher thread if connection has SendAsap option set

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -53,8 +53,8 @@ natsConn_isClosed(natsConnection *nc);
 bool
 natsConn_isReconnecting(natsConnection *nc);
 
-void
-natsConn_kickFlusher(natsConnection *nc);
+natsStatus
+natsConn_flushOrKickFlusher(natsConnection *nc);
 
 natsStatus
 natsConn_processMsg(natsConnection *nc, char *buf, int bufLen);

--- a/src/pub.c
+++ b/src/pub.c
@@ -148,10 +148,10 @@ _publishEx(natsConnection *nc, const char *subj,
 
     if (s == NATS_OK)
     {
-        if (directFlush || nc->opts->sendAsap)
+        if (directFlush)
             s = natsConn_bufferFlush(nc);
         else
-            natsConn_kickFlusher(nc);
+            s = natsConn_flushOrKickFlusher(nc);
     }
 
     if (s == NATS_OK)

--- a/test/list.txt
+++ b/test/list.txt
@@ -36,6 +36,7 @@ ParserSplitMsg
 LibMsgDelivery
 AsyncINFO
 RequestPool
+NoFlusherIfSendAsapOption
 DefaultConnection
 IPResolutionOrder
 UseDefaultURLIfNoServerSpecified


### PR DESCRIPTION
Don't use a connection's flusher thread if the connection sends
data as soon as possible.