### PR TITLE
[IMPROVED] URL parsing allowing to skip scheme and default port

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -668,7 +668,10 @@ _checkForSecure(natsConnection *nc)
     if (nc->opts->secure && !nc->info.tlsRequired)
         s = nats_setDefaultError(NATS_SECURE_CONNECTION_WANTED);
     else if (nc->info.tlsRequired && !nc->opts->secure)
-        s = nats_setDefaultError(NATS_SECURE_CONNECTION_REQUIRED);
+    {
+        // Switch to Secure since server needs TLS.
+        s = natsOptions_SetSecure(nc->opts, true);
+    }
 
     if ((s == NATS_OK) && nc->opts->secure)
         s = _makeTLSConn(nc);

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -99,6 +99,8 @@ static const char *inboxPrefix = "_INBOX.";
 #define WAIT_FOR_WRITE      (1)
 #define WAIT_FOR_CONNECT    (2)
 
+#define DEFAULT_PORT_STRING "4222"
+
 #define MAX_FRAMES (50)
 
 extern int64_t gLockSpinCount;

--- a/test/list.txt
+++ b/test/list.txt
@@ -38,6 +38,7 @@ AsyncINFO
 RequestPool
 NoFlusherIfSendAsapOption
 DefaultConnection
+SimplifiedURLs
 IPResolutionOrder
 UseDefaultURLIfNoServerSpecified
 ConnectToWithMultipleURLs

--- a/test/tls_default_port.conf
+++ b/test/tls_default_port.conf
@@ -1,0 +1,15 @@
+
+# Simple TLS config file
+
+port: 4222
+net: "0.0.0.0"
+
+tls {
+  # Server cert
+  cert_file: "certs/server-cert.pem"
+  # Server private key
+  key_file:  "certs/server-key.pem"
+  # Increase timeout for valgrind tests
+  timeout: 2
+}
+


### PR DESCRIPTION
- Allow URLs to not have scheme or port (in which case default
  port 4222 is added).
- Switch to secure connection automatically if server requires
  TLS.
- Fixed test on Windows.

Resolves #159

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>