### PR TITLE
Changes to drain mode implementation

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -77,7 +77,10 @@ natsConn_subscribe(natsSubscription **newSub,
                    int64_t timeout, natsMsgHandler cb, void *cbClosure);
 
 natsStatus
-natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max, bool drainMode);
+natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max);
+
+natsStatus
+natsConn_drainSub(natsConnection *nc, natsSubscription *sub, bool checkConnDrainStatus);
 
 bool
 natsConn_isDraining(natsConnection *nc);

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -280,6 +280,11 @@ struct __natsSubscription
     // Indicates if this subscription is in drained mode.
     bool                        draining;
 
+    // Same than draining but for the global delivery situation.
+    // This boolean will be switched off when processed, as opposed
+    // to draining that once set does not get reset.
+    bool                        libDlvDraining;
+
     // If true, the subscription is closed, but because the connection
     // was closed, not because of subscription (auto-)unsubscribe.
     bool                        connClosed;

--- a/src/sub.h
+++ b/src/sub.h
@@ -39,11 +39,11 @@ natsStatus
 natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
                const char *queueGroup, int64_t timeout, natsMsgHandler cb, void *cbClosure);
 
-natsStatus
-natsSub_unsubscribe(natsSubscription *sub, int max, bool drain, bool checkDrainStatus);
-
 void
 natsSub_setMax(natsSubscription *sub, uint64_t max);
+
+void
+natsSub_drain(natsSubscription *sub);
 
 void
 natsSub_close(natsSubscription *sub, bool connectionClosed);


### PR DESCRIPTION
API remain the same, just changed the implementation to reduce
use of threads and also works for sync subs and global delivery
thread pool.

Related to PR #161

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>