### PR TITLE
Changes to Drain implementation

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -434,8 +434,8 @@ struct __natsConnection
 
     natsStatistics      stats;
 
-    natsThread          *drainThread;
-    int64_t             drainTimeout;
+    natsTimer           *drainTimer;
+    int64_t             drainDeadline;
 
     // New Request style
     char                respId[NATS_MAX_REQ_ID_LEN+1];

--- a/src/sub.c
+++ b/src/sub.c
@@ -730,13 +730,19 @@ natsSub_drain(natsSubscription *sub)
 natsStatus
 natsSubscription_Drain(natsSubscription *sub)
 {
-    natsStatus      s;
+    natsStatus      s   = NATS_OK;
     natsConnection  *nc = NULL;
 
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     natsSub_Lock(sub);
+    // If not closed and draining, return OK.
+    if (!sub->closed && sub->draining)
+    {
+        natsSub_Unlock(sub);
+        return NATS_OK;
+    }
     nc = sub->conn;
     _retain(sub);
     natsSub_Unlock(sub);


### PR DESCRIPTION
- Calling drain (on sub or conn) when already in drain mode should
  not return an error.
- Changed the implementation of the connection drain to not require
  a thread (use timer instead).
- Added more tests, including auto-unsub.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>