### PR TITLE
[CHANGED] natsConnStatus enum to use NATS_CONN_STATUS_ prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(NATS_BUILD_LIBUV_EXAMPLE "Build libuv examples" OFF)
 option(NATS_BUILD_LIBEVENT_EXAMPLE "Build libevent examples" OFF)
 option(NATS_BUILD_STATIC_EXAMPLES "Statically link examples" OFF)
 option(NATS_BUILD_STREAMING "Build NATS Streaming" ON)
+option(NATS_BUILD_NO_PREFIX_CONNSTS "No prefix for connection status enum" OFF)
 
 if(NATS_BUILD_WITH_TLS)
   find_package(OpenSSL REQUIRED)
@@ -34,6 +35,10 @@ if(NATS_BUILD_STREAMING)
   set(NATS_DOC_INCLUDE_STREAMING "NATS_HAS_STREAMING")
   set(NATS_DOC_PROJECT_NAME "NATS C Client with Streaming support")
 endif(NATS_BUILD_STREAMING)
+
+if(NATS_BUILD_NO_PREFIX_CONNSTS)
+  add_definitions(-DNATS_CONN_STATUS_NO_PREFIX)
+endif(NATS_BUILD_NO_PREFIX_CONNSTS)
 
 # Platform specific settings
 if(UNIX)

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -116,6 +116,18 @@ static const char *inboxPrefix = "_INBOX.";
         if ((s) == NATS_OK) \
             DUP_STRING((s), (s1), (s2))
 
+// This is temporary until we remove original connection status enum
+// values without NATS_CONN_STATUS_ prefix
+#if defined(NATS_CONN_STATUS_NO_PREFIX)
+#define NATS_CONN_STATUS_DISCONNECTED   DISCONNECTED
+#define NATS_CONN_STATUS_CONNECTING     CONNECTING
+#define NATS_CONN_STATUS_CONNECTED      CONNECTED
+#define NATS_CONN_STATUS_CLOSED         CLOSED
+#define NATS_CONN_STATUS_RECONNECTING   RECONNECTING
+#define NATS_CONN_STATUS_DRAINING_SUBS  DRAINING_SUBS
+#define NATS_CONN_STATUS_DRAINING_PUBS  DRAINING_PUBS
+#endif
+
 extern int64_t gLockSpinCount;
 
 typedef void (*natsInitOnceCb)(void);

--- a/src/status.h
+++ b/src/status.h
@@ -18,9 +18,14 @@
 extern "C" {
 #endif
 
+
 /// The connection state
 typedef enum
 {
+#if defined(NATS_CONN_STATUS_NO_PREFIX)
+    // This is deprecated and applications referencing connection
+    // status should be updated to use the values prefixed with NATS_CONN_STATUS_.
+
     DISCONNECTED = 0, ///< The connection has been disconnected
     CONNECTING,       ///< The connection is in the process or connecting
     CONNECTED,        ///< The connection is connected
@@ -28,6 +33,15 @@ typedef enum
     RECONNECTING,     ///< The connection is in the process or reconnecting
     DRAINING_SUBS,    ///< The connection is draining subscriptions
     DRAINING_PUBS,    ///< The connection is draining publishers
+#else
+    NATS_CONN_STATUS_DISCONNECTED = 0, ///< The connection has been disconnected
+    NATS_CONN_STATUS_CONNECTING,       ///< The connection is in the process or connecting
+    NATS_CONN_STATUS_CONNECTED,        ///< The connection is connected
+    NATS_CONN_STATUS_CLOSED,           ///< The connection is closed
+    NATS_CONN_STATUS_RECONNECTING,     ///< The connection is in the process or reconnecting
+    NATS_CONN_STATUS_DRAINING_SUBS,    ///< The connection is draining subscriptions
+    NATS_CONN_STATUS_DRAINING_PUBS,    ///< The connection is draining publishers
+#endif
 
 } natsConnStatus;
 

--- a/test/test.c
+++ b/test/test.c
@@ -2572,9 +2572,7 @@ test_natsJSON(void)
             "{ \"test\": {\"inner\":\"not \\\"supported\\\", at this time\"}}",
             "{ \"test\":[\"a\", \"b\", \"c\", 1]}",
             "{ \"test\": \"a\\\"b\\\"c\"}",
-            "{ \"test\": \"\\\"\\\\/\b\f\n\r\t\uabcd\"}",
-            "{ \"test\": \"\ua12f\"}",
-            "{ \"test\": \"\uA01F\"}",
+            "{ \"test\": \"\\\"\\\\/\b\f\n\r\t\u016A\"}",
     };
 
     for (i=0; i<(int)(sizeof(wrong)/sizeof(char*)); i++)


### PR DESCRIPTION
The current enum values are too common and cause collisions when
other network libraries are used.

Resolves #168

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>