### PR TITLE
[IMPROVED] Use CMake variable for deployment destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,6 @@ list(APPEND NATS_INSTALLED_FILES "${CMAKE_INSTALL_PREFIX}/${NATS_LIBDIR}/libnats
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${NATS_INSTALLED_FILES}")
 #---------------------------------------------------------------------
 
-if(NATS_UPDATE_VERSION OR NATS_UPDATE_DOC)
 #------------
 # Versionning and Doc
 
@@ -150,6 +149,7 @@ set(NATS_VERSION_SUFFIX "-beta")
 
 set(NATS_VERSION_REQUIRED_NUMBER 0x010100)
 
+if(NATS_UPDATE_VERSION OR NATS_UPDATE_DOC)
 configure_file(
 	${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
 	${CMAKE_CURRENT_SOURCE_DIR}/src/version.h
@@ -159,8 +159,8 @@ configure_file(
 	${CMAKE_SOURCE_DIR}/doc/DoxyFile.NATS.Client.in
 	${CMAKE_SOURCE_DIR}/doc/DoxyFile.NATS.Client
 	@ONLY)
-#------------
 endif(NATS_UPDATE_VERSION OR NATS_UPDATE_DOC)
+#------------
 
 #----------------------------
 # Add the project directories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,12 +33,15 @@ add_library(nats SHARED ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
 target_link_libraries(nats ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB} ${NATS_PROTOBUF_LIB})
 add_library(nats_static STATIC ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
 target_link_libraries(nats_static ${NATS_OPENSSL_LIBS} ${NATS_PROTOBUF_LIB})
+set_target_properties(nats nats_static PROPERTIES
+  VERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR}.${NATS_VERSION_PATCH}
+  SOVERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR})
 
 # --------------------------------------
 # Install the libraries and header files
 # --------------------------------------
-install(TARGETS nats DESTINATION ${NATS_LIBDIR})
-install(TARGETS nats_static DESTINATION ${NATS_LIBDIR})
+install(TARGETS nats LIBRARY DESTINATION ${NATS_LIBDIR})
+install(TARGETS nats_static ARCHIVE DESTINATION ${NATS_LIBDIR})
 install(FILES deprnats.h DESTINATION ${NATS_INCLUDE_DIR} RENAME nats.h)
 install(FILES nats.h status.h version.h DESTINATION ${NATS_INCLUDE_DIR}/nats)
 install(FILES adapters/libevent.h adapters/libuv.h DESTINATION ${NATS_INCLUDE_DIR}/nats/adapters)

--- a/test/test.c
+++ b/test/test.c
@@ -2572,9 +2572,9 @@ test_natsJSON(void)
             "{ \"test\": {\"inner\":\"not \\\"supported\\\", at this time\"}}",
             "{ \"test\":[\"a\", \"b\", \"c\", 1]}",
             "{ \"test\": \"a\\\"b\\\"c\"}",
-            "{ \"test\": \"\\\"\\\\/\b\f\n\r\t\uabcd\"}",
-            "{ \"test\": \"\ua12f\"}",
-            "{ \"test\": \"\uA01F\"}",
+            "{ \"test\": \"\\\"\\\\/\b\f\n\r\t\\uabcd\"}",
+            "{ \"test\": \"\\ua12f\"}",
+            "{ \"test\": \"\\uA01F\"}",
     };
 
     for (i=0; i<(int)(sizeof(wrong)/sizeof(char*)); i++)


### PR DESCRIPTION
Here is the proper fix for the https://github.com/nats-io/cnats/pull/172.

Location of libraries and development files may be different when building for different platforms. CMake can handle this just fine, however, the current cmake configuration does not use these facilities. This merge request fixes that.