### PR TITLE
[FIXED] Ensure internal subscriptions not pooled

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1127,7 +1127,7 @@ natsConn_createRespMux(natsConnection *nc, char *ginbox, natsMsgHandler cb)
     natsStatus          s    = NATS_OK;
     natsSubscription    *sub = NULL;
 
-    s = natsConn_subscribe(&sub, nc, ginbox, NULL, 0, cb, (void*) nc);
+    s = natsConn_subscribeNoPool(&sub, nc, ginbox, cb, (void*) nc);
     if (s == NATS_OK)
     {
         // Between a successful creation of the subscription and
@@ -2449,9 +2449,10 @@ natsConn_removeSubscription(natsConnection *nc, natsSubscription *removedSub)
 // subscribe is the internal subscribe function that indicates interest in a
 // subject.
 natsStatus
-natsConn_subscribe(natsSubscription **newSub,
-                   natsConnection *nc, const char *subj, const char *queue,
-                   int64_t timeout, natsMsgHandler cb, void *cbClosure)
+natsConn_subscribeImpl(natsSubscription **newSub,
+                       natsConnection *nc, const char *subj, const char *queue,
+                       int64_t timeout, natsMsgHandler cb, void *cbClosure,
+                       bool preventUseOfLibDlvPool)
 {
     natsStatus          s    = NATS_OK;
     natsSubscription    *sub = NULL;
@@ -2478,7 +2479,7 @@ natsConn_subscribe(natsSubscription **newSub,
         return nats_setDefaultError(NATS_DRAINING);
     }
 
-    s = natsSub_create(&sub, nc, subj, queue, timeout, cb, cbClosure);
+    s = natsSub_create(&sub, nc, subj, queue, timeout, cb, cbClosure, preventUseOfLibDlvPool);
     if (s == NATS_OK)
     {
         natsMutex_Lock(nc->subsMu);

--- a/src/conn.h
+++ b/src/conn.h
@@ -71,10 +71,20 @@ natsConn_processPing(natsConnection *nc);
 void
 natsConn_processPong(natsConnection *nc);
 
+#define natsConn_subscribeNoPool(sub, nc, subj, cb, closure)                            natsConn_subscribeImpl((sub), (nc), (subj), NULL, 0, (cb), (closure), true)
+#define natsConn_subscribeSyncNoPool(sub, nc, subj)                                     natsConn_subscribeNoPool((sub), (nc), (subj), NULL, NULL)
+#define natsConn_subscribeWithTimeout(sub, nc, subj, timeout, cb, closure)              natsConn_subscribeImpl((sub), (nc), (subj), NULL, (timeout), (cb), (closure), false)
+#define natsConn_subscribe(sub, nc, subj, cb, closure)                                  natsConn_subscribeWithTimeout((sub), (nc), (subj), 0, (cb), (closure))
+#define natsConn_subscribeSync(sub, nc, subj)                                           natsConn_subscribe((sub), (nc), (subj), NULL, NULL)
+#define natsConn_queueSubscribeWithTimeout(sub, nc, subj, queue, timeout, cb, closure)  natsConn_subscribeImpl((sub), (nc), (subj), (queue), (timeout), (cb), (closure), false)
+#define natsConn_queueSubscribe(sub, nc, subj, queue, cb, closure)                      natsConn_queueSubscribeWithTimeout((sub), (nc), (subj), (queue), 0, (cb), (closure))
+#define natsConn_queueSubscribeSync(sub, nc, subj, queue)                               natsConn_queueSubscribe((sub), (nc), (subj), (queue), NULL, NULL)
+
 natsStatus
-natsConn_subscribe(natsSubscription **newSub,
-                   natsConnection *nc, const char *subj, const char *queue,
-                   int64_t timeout, natsMsgHandler cb, void *cbClosure);
+natsConn_subscribeImpl(natsSubscription **newSub,
+                       natsConnection *nc, const char *subj, const char *queue,
+                       int64_t timeout, natsMsgHandler cb, void *cbClosure,
+                       bool preventUseOfLibDlvPool);
 
 natsStatus
 natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max);

--- a/src/pub.c
+++ b/src/pub.c
@@ -265,7 +265,7 @@ _oldRequest(natsMsg **replyMsg, natsConnection *nc, const char *subj,
 
     s = natsInbox_init(inbox, sizeof(inbox));
     if (s == NATS_OK)
-        s = natsConn_subscribe(&sub, nc, inbox, NULL, 0, NULL, NULL);
+        s = natsConn_subscribeSyncNoPool(&sub, nc, inbox);
     if (s == NATS_OK)
         s = natsSubscription_AutoUnsubscribe(sub, 1);
     if (s == NATS_OK)

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -349,7 +349,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
         s = natsInbox_Create(&sc->hbInbox);
     if (s == NATS_OK)
     {
-        s = natsConnection_Subscribe(&sc->hbSubscription, sc->nc, sc->hbInbox, _processHeartBeat, NULL);
+        s = natsConn_subscribeNoPool(&sc->hbSubscription, sc->nc, sc->hbInbox, _processHeartBeat, NULL);
         if (s == NATS_OK)
         {
             natsSubscription_SetPendingLimits(sc->hbSubscription, -1, -1);
@@ -364,7 +364,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
     {
         s = natsInbox_Create((char**) &pingInbox);
         if (s == NATS_OK)
-            s = natsConnection_Subscribe(&pingSub, sc->nc, pingInbox, _processPingResponse, (void*) sc);
+            s = natsConn_subscribeNoPool(&pingSub, sc->nc, pingInbox, _processPingResponse, (void*) sc);
         if (s == NATS_OK)
         {
             // Mark this as needing a destroy if we end up not using PINGs.
@@ -513,7 +513,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
         IF_OK_DUP_STRING(s, sc->ackSubject, (char*)tmp);
 
         if (s == NATS_OK)
-            s = natsConnection_Subscribe(&sc->ackSubscription, sc->nc, sc->ackSubject, stanProcessPubAck, (void*) sc);
+            s = natsConn_subscribeNoPool(&sc->ackSubscription, sc->nc, sc->ackSubject, stanProcessPubAck, (void*) sc);
         if (s == NATS_OK)
         {
             natsSubscription_SetPendingLimits(sc->ackSubscription, -1, -1);

--- a/src/sub.h
+++ b/src/sub.h
@@ -37,7 +37,8 @@ natsSub_release(natsSubscription *sub);
 
 natsStatus
 natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
-               const char *queueGroup, int64_t timeout, natsMsgHandler cb, void *cbClosure);
+               const char *queueGroup, int64_t timeout, natsMsgHandler cb, void *cbClosure,
+               bool noLibDlvPool);
 
 void
 natsSub_setMax(natsSubscription *sub, uint64_t max);

--- a/test/list.txt
+++ b/test/list.txt
@@ -164,3 +164,4 @@ StanPings
 StanPingsUnblockPublishCalls
 StanGetNATSConnection
 StanNoRetryOnFailedConnect
+StanInternalSubsNotPooled


### PR DESCRIPTION
If user wishes to use global message delivery through use of library
deliver thread pool, internal subscriptions should not be part of
that since a slow user callback may then affect processing of
internal messages.

The Streaming library is using internal subscriptions for hearbeats,
acks, and pings and so this makes sure that these are not possibly
pooled and mixed with user callbacks.

The core library is also using a subscription for request/replies
and that subscription also should not be pooled.

Resolves #178

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>