### PR TITLE
[IMPROVED] natsConnection_Close() now internally calls FlushTimeout()

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -79,6 +79,7 @@ AsyncSubscribeTimeout
 SyncSubscribe
 PubSubWithReply
 Flush
+ConnCloseDoesFlush
 QueueSubscriber
 ReplyArg
 SyncReplyArg


### PR DESCRIPTION
This ensures that anything that is in the buffer is not only flushed
but that the server has processed anything that was sent by the
connection prior to the close call.

Resolves #188

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>